### PR TITLE
Nuget Fixes

### DIFF
--- a/Verify.Marshaling.Tests/BasicTests.TestMarshalableTypes_t=Verify.Marshaling.Tests.Fixtures.BigStruct.verified.txt
+++ b/Verify.Marshaling.Tests/BasicTests.TestMarshalableTypes_t=Verify.Marshaling.Tests.Fixtures.BigStruct.verified.txt
@@ -1,0 +1,50 @@
+﻿{
+  FieldName: BigStruct,
+  Size: 176,
+  Nested: [
+    {
+      FieldName: Test,
+      Size: 4,
+      Type: Int32
+    },
+    {
+      FieldName: TestF,
+      Size: 4,
+      Offset: 4,
+      Type: Single
+    },
+    {
+      FieldName: TestA,
+      Size: 4,
+      Offset: 8,
+      Type: Int32
+    },
+    {
+      FieldName: TestB,
+      Size: 4,
+      Offset: 12,
+      Type: Int32
+    },
+    {
+      FieldName: SimpleStruct,
+      Size: 160,
+      Offset: 16,
+      Count: 20,
+      Nested: [
+        {
+          FieldName: Test,
+          Size: 4,
+          Type: Int32
+        },
+        {
+          FieldName: TestF,
+          Size: 4,
+          Offset: 4,
+          Type: Single
+        }
+      ],
+      Type: array
+    }
+  ],
+  Type: struct
+}

--- a/Verify.Marshaling.Tests/BasicTests.cs
+++ b/Verify.Marshaling.Tests/BasicTests.cs
@@ -3,8 +3,9 @@
 using Verify.Marshaling.Tests.Fixtures;
 namespace Verify.Marshaling.Tests;
 
+[UsesVerify]
 [TestClass]
-public partial class BasicTests: VerifyBase
+public partial class BasicTests
 {
     [DataRow(typeof(CMP_CompressOptions))]
     [DataRow(typeof(SimpleStruct))]
@@ -12,10 +13,10 @@ public partial class BasicTests: VerifyBase
     [DataRow(typeof(StringStruct))]
     [DataRow(typeof(ArrayStruct))]
     [DataRow(typeof(NoAttributeStruct))]
+    [DataRow(typeof(BigStruct))]
     [TestMethod]
     public async Task TestMarshalableTypes(Type t)
     {
-        //await Verify(t);
         await VerifyMarshaling.VerifyMemoryLayout(t);
     }
 

--- a/Verify.Marshaling.Tests/Fixtures/TestStructs.cs
+++ b/Verify.Marshaling.Tests/Fixtures/TestStructs.cs
@@ -51,12 +51,44 @@ public struct StringStruct
     public string B;
 }
 
-// Bad Structs
+public struct BigStruct
+{
+    [MarshalAs(UnmanagedType.I4)]
+    public int Test;
+
+    [MarshalAs(UnmanagedType.R4)]
+    public float TestF;
+
+    [MarshalAs(UnmanagedType.I4)]
+    public int TestA;
+
+    [MarshalAs(UnmanagedType.I4)]
+    public int TestB;
+
+    // 20 SIMPLE STRUCTS
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+    public SimpleStruct[] cmdSet;
+}
+
+#region Bad Structs
+
+/// <summary>
+/// Automatic layout struct. NOT SUPPORTED.
+/// </summary>
 [StructLayout(LayoutKind.Auto)]
-public struct AutoStruct { }
+public struct AutoStruct { } 
+
+/// <summary>
+/// Has no attribute, treated as sequential.
+/// </summary>
 public struct NoAttributeStruct { } // NO ATTRIBUTE!
 
+/// <summary>
+/// Strings without a marshalas, cannot be marshaled correctly.
+/// </summary>
 [StructLayout(LayoutKind.Sequential)]
 public struct BadStringStruct {
     public string A; // No Marshal As
 }
+#endregion
+

--- a/Verify.Marshaling.Tests/TestMarshalingSizes.cs
+++ b/Verify.Marshaling.Tests/TestMarshalingSizes.cs
@@ -4,6 +4,8 @@ using Verify.Marshaling.Utilities;
 
 namespace Verify.Marshaling.Tests;
 
+// See: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.unmanagedtype?view=net-9.0 for info
+
 [TestClass]
 public sealed class TestMarshalingSizes
 {
@@ -20,15 +22,30 @@ public sealed class TestMarshalingSizes
     [DataRow(UnmanagedType.I8, 8)]
     [DataRow(UnmanagedType.U8, 8)]
     [DataRow(UnmanagedType.R8, 8)]
-    //[DataRow(UnmanagedType.LPStr, 1)] // Not Implemented
-    //[DataRow(UnmanagedType.LPTStr, 1)] // Not Implemented
     [DataRow(UnmanagedType.ByValTStr, 1)]
+    [DataRow(UnmanagedType.SysInt, 8)]
+    [DataRow(UnmanagedType.SysUInt, 8)]
+    [DataRow(UnmanagedType.Error, 4)]
     [TestMethod]
     public void TestUnmanagedTypeSizes(UnmanagedType type, int expectedSize)
     {
         Assert.AreEqual(expectedSize, type.GetSize());
     }
 
+    //TODO: Move these, Up one method when they are implemented
+    [DataRow(UnmanagedType.LPStr, 1)]
+    [DataRow(UnmanagedType.LPTStr, 1)]
+    [DataRow(UnmanagedType.LPUTF8Str, 1)]
+    [DataRow(UnmanagedType.LPWStr, 1)]
+    [DataRow(UnmanagedType.IInspectable, 1)]
+    [DataRow(UnmanagedType.IUnknown, 1)]
+    [DataRow(UnmanagedType.HString, 1)]
+    [DataRow(UnmanagedType.CustomMarshaler, 1)]
+    [TestMethod]
+    public void TestUnmanagedTypeSizesNotImplemented(UnmanagedType type, int expectedSize)
+    {
+        Assert.Throws<NotImplementedException>(() => type.GetSize());
+    }
 
     [TestMethod]
     public void TestComplexUnmanagedTypes()
@@ -39,22 +56,38 @@ public sealed class TestMarshalingSizes
         Assert.AreEqual(UIntPtr.Size, UnmanagedType.SysUInt.GetSize());
     }
 
-    //case UnmanagedType.ByValTStr:
-    //        return (GetSize(type)* attribute.SizeConst);
-    //    case UnmanagedType.ByValArray:
-    //        return (GetSize(attribute.ArraySubType)* attribute.SizeConst);
-    //    case UnmanagedType.SafeArray:
-    //        return (GetSize(attribute.ArraySubType)* attribute.SizeConst);
-
     [DataRow(5, UnmanagedType.ByValTStr, 5)]
     [DataRow(1, UnmanagedType.ByValTStr, 1)]
     [TestMethod]
-    public void TestVariableLengthSizes(int expectedSize, UnmanagedType type, int size)
+    public void TestVariableLengthStrings(int expectedSize, UnmanagedType type, int size)
     {
         var m = new MarshalAsAttribute(type);
         m.SizeConst = size;
 
         Assert.AreEqual(expectedSize, m.GetSize());
+    }
+
+    [DataRow(5, UnmanagedType.ByValArray, UnmanagedType.U1, 5)]
+    [DataRow(20, UnmanagedType.ByValArray, UnmanagedType.R4, 5)]
+    [DataRow(20, UnmanagedType.LPArray, UnmanagedType.R4, 5)]
+    [TestMethod]
+    public void TestUnmanagedArrayLengths(int expectedSize, UnmanagedType type, UnmanagedType arraySubType, int size)
+    {
+        var m = new MarshalAsAttribute(type);
+        m.SizeConst = size;
+        m.ArraySubType = arraySubType;
+
+        Assert.AreEqual(expectedSize, m.GetSize());
+    }
+
+    //TODO: Move these, Up one method when they are implemented
+    [DataRow(20, UnmanagedType.SafeArray, UnmanagedType.R4, 5)]
+    [DataRow(20, UnmanagedType.LPWStr, UnmanagedType.R4, 5)]
+    [DataRow(20, UnmanagedType.BStr, UnmanagedType.R4, 5)]
+    [TestMethod]
+    public void TestNotImplementedArrayTypes(int expectedSize, UnmanagedType type, UnmanagedType arraySubType, int size)
+    {
+        Assert.Throws<NotImplementedException>(() => TestUnmanagedArrayLengths(expectedSize, type, arraySubType, size));
     }
 
     [TestMethod]
@@ -67,5 +100,5 @@ public sealed class TestMarshalingSizes
         {
             Assert.AreEqual(960, MarshalRecord.GetSize(f));
         }
-    }
+    }    
 }

--- a/Verify.Marshaling/Utilities/MarshalingExtensions.cs
+++ b/Verify.Marshaling/Utilities/MarshalingExtensions.cs
@@ -9,23 +9,28 @@ internal static class MarshalingExtensions
         var type = attribute.Value;
         switch (type)
         {
+            // Strings
             case UnmanagedType.LPStr:
                 return (GetSize(type) * attribute.SizeConst) + 1;
+            case UnmanagedType.ByValTStr:
+                return (GetSize(type) * attribute.SizeConst);
+
+            // Arrays
+            case UnmanagedType.ByValArray:
+            case UnmanagedType.LPArray:
+                if (attribute.ArraySubType == 0)
+                    throw new InvalidOperationException($"Expected ArraySubType when getting size of {type}");
+                return (GetSize(attribute.ArraySubType) * attribute.SizeConst);
+            
+            // Not Implemented
+            case UnmanagedType.SafeArray:
             case UnmanagedType.LPWStr:
             case UnmanagedType.LPTStr:
             case UnmanagedType.BStr:
                 //TODO: how many bytes are these?
                 throw new NotImplementedException($"{type} is not supported or unknown.");
-
-            case UnmanagedType.ByValTStr:
-                return (GetSize(type) * attribute.SizeConst);
-            case UnmanagedType.ByValArray:
-                return (GetSize(attribute.ArraySubType) * attribute.SizeConst);
-            case UnmanagedType.SafeArray:
-                return (GetSize(attribute.ArraySubType) * attribute.SizeConst);
-
             case UnmanagedType.Struct:
-                throw new NotImplementedException($"Nested not supported");
+                throw new NotImplementedException($"Nested structs are not supported");
             default:
                 return GetSize(attribute.Value);
         }
@@ -37,7 +42,6 @@ internal static class MarshalingExtensions
             case UnmanagedType.I1:
             case UnmanagedType.U1:
                 return 1;
-
             case UnmanagedType.I2:
             case UnmanagedType.U2:
                 return 2;
@@ -63,7 +67,7 @@ internal static class MarshalingExtensions
                 return 1;
         }
 
-        throw new NotImplementedException($"{unmanagedType} is not supported or unknown.");
+        throw new NotImplementedException($"{Enum.GetName(unmanagedType)} is not supported or unknown.");
     }
 }
 

--- a/Verify.Marshaling/VerifyMarshaling.cs
+++ b/Verify.Marshaling/VerifyMarshaling.cs
@@ -21,16 +21,22 @@ public static class VerifyMarshaling
 
         InnerVerifier.ThrowIfVerifyHasBeenRun();
 
-        //TODO: we don't actually need to do anything here, but this keeps it in the VerifyTests namespace.
+        //TODO: we don't actually need to do anything here, but this keeps it in the VerifyTests namespace. See other TODO's in this file.
     }
+
+    /// <summary>
+    /// Given a C# type, validate its struct memory layout using Verify.
+    /// </summary>
+    /// <param name="t">Target type</param>
+    /// <param name="settings">VerifySettings to apply if needed</param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    //TODO: Validate this approach. This approach is a little hacky, but its how we "got things working" PRs to improve it are welcome.
+    //TODO: Should we restrict the Typing of t? To just classes and structs?
     public static SettingsTask VerifyMemoryLayout(Type t, VerifySettings? settings = null, [CallerFilePath] string sourceFile = "", [CallerMemberName] string memberName = "")
     {
-        // TODO: This feels like a massive hack, but technicallly works quite well. I ran out of energy!
-
-        VerifierSettings.AssignTargetAssembly(t.Assembly);
-
         // Somewhat hacky, Verify does this through Extensive orchestration
-        // in the test Framework specific libraries. We Just get the filename :S
+        // in the test Framework specific libraries. We just need to get the filename.
         var typeName = Path.GetFileNameWithoutExtension(sourceFile); 
 
         // This isn't used, it just needs to be not null.


### PR DESCRIPTION
- Fix Assembly Assignment - This isn't our responsibility, the test harness should handle it.
- Tweak tests - we had a bunch of undefined behavior and comments. I've implemented more of the easier types.